### PR TITLE
use JetReconstruction main in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,10 @@ ONNXRunTime = "e034b28e-924e-41b2-b98f-d2bbeb830c6a"
 PhysicalConstants = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 
+[sources]
+# to be removed after JetReconstruction v1.0.0 is released
+JetReconstruction = {rev = "main", url = "https://github.com/JuliaHEP/JetReconstruction.jl"}
+
 [compat]
 EDM4hep = "0.4.0"
 JSON = "0.21"


### PR DESCRIPTION
Instantiating the package and CI fails since the package uses JetReconstuction main API form upcoming v1.0.
The sources can be used to inform package manager to use main instead of looking for version available from the package registery

This will fail for Julia lts as `sources` directive for Project.toml was added only in Julia 1.11